### PR TITLE
chore: add Rslint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,34 @@
+name: Lint
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Pnpm
+        run: npm i -g corepack@latest --force && corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22.x
+          cache: 'pnpm'
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Run Lint
+        run: pnpm run lint

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "rstack.rslint"
+  ]
+}

--- a/copy-plugin/CopyPlugin.test.js
+++ b/copy-plugin/CopyPlugin.test.js
@@ -802,16 +802,12 @@ describe("CopyPlugin", () => {
       expect(stats.toJson().errors).toMatchSnapshot("errors");
       expect(stats.toJson().warnings).toMatchSnapshot("warnings");
 
-      await new Promise(async (resolve) => {
-        const { stats: newStats } = await compile(compiler);
+      const { stats: newStats } = await compile(compiler);
 
-        expect(newStats.compilation.emittedAssets.size).toBe(0);
-        expect(readAssets(compiler, newStats)).toMatchSnapshot("assets");
-        expect(newstats.toJson().errors).toMatchSnapshot("errors");
-        expect(newstats.toJson().warnings).toMatchSnapshot("warnings");
-
-        resolve();
-      });
+      expect(newStats.compilation.emittedAssets.size).toBe(0);
+      expect(readAssets(compiler, newStats)).toMatchSnapshot("assets");
+      expect(newStats.toJson().errors).toMatchSnapshot("errors");
+      expect(newStats.toJson().warnings).toMatchSnapshot("warnings");
     });
 
     it('should work with the "filesystem" cache', async () => {

--- a/css-extract/TestCases.test.js
+++ b/css-extract/TestCases.test.js
@@ -63,7 +63,7 @@ function getHashes(webpackStats) {
 			acc[name] = i.info.fullhash.join("");
 		}
 		if (i.info?.contenthash?.length) {
-			for (const hash of i.info?.contenthash) {
+			for (const hash of i.info.contenthash) {
 				name = `__CONTENT_${normalizePath(name.replace(`$${hash}$`, "DH").replace(hash, "H"))}_HASH__`;
 			}
 			acc[name] = i.info.contenthash.join("");
@@ -397,7 +397,7 @@ describe("TestCases", () => {
 										.replace(/\(from .*\)?/g, "(from xxx)")
 										.replace(/\*\scss\s(.*)?!/g, "* css /path/to/loader.js!")
 										.replace(/\*\scss\s(.*)?!/g, "* css /path/to/loader.js!")
-										.replace(/│     at .*\n/g, "")
+										.replace(/│ {5}at .*\n/g, "")
 										.trim()
 								).toBe(
 									stripAnsi(expectedWarnings)
@@ -406,7 +406,7 @@ describe("TestCases", () => {
 										.filter(Boolean)
 										.join("\n")
 										.replace(/\*\scss\s(.*)?!/g, "* css /path/to/loader.js!")
-										.replace(/│     at .*\n/g, "")
+										.replace(/│ {5}at .*\n/g, "")
 										.trim()
 								);
 							}

--- a/css-extract/helpers/runInJsDom.js
+++ b/css-extract/helpers/runInJsDom.js
@@ -7,9 +7,8 @@ function runInJsDom(assetName, compiler, stats, testFn) {
 
 	virtualConsole.sendTo(console);
 
-	try {
-		const dom = new JSDOM(
-			`<!doctype html>
+	const dom = new JSDOM(
+		`<!doctype html>
 <html>
 <head>
   <title>style-loader test</title>
@@ -22,22 +21,19 @@ function runInJsDom(assetName, compiler, stats, testFn) {
 </body>
 </html>
 `,
-			{
-				resources: "usable",
-				runScripts: "dangerously",
-				virtualConsole
-			}
-		);
+		{
+			resources: "usable",
+			runScripts: "dangerously",
+			virtualConsole
+		}
+	);
 
-		dom.window.eval(bundle);
+	dom.window.eval(bundle);
 
-		testFn(dom, bundle);
+	testFn(dom, bundle);
 
-		// free memory associated with the window
-		dom.window.close();
-	} catch (e) {
-		throw e;
-	}
+	// free memory associated with the window
+	dom.window.close();
 }
 
 export default runInJsDom;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "license": "MIT",
   "scripts": {
     "test": "rstest",
-    "testu": "rstest -u"
+    "testu": "rstest -u",
+    "lint": "rslint",
+    "lint:write": "rslint --fix"
   },
   "engines": {
     "pnpm": "9.15.9"
@@ -18,6 +20,7 @@
     "@rspack/cli": "2.0.1",
     "@webdiscus/pug-loader": "^2.11.1",
     "@rstest/core": "^0.9.10",
+    "@rslint/core": "^0.5.1",
     "@types/cross-spawn": "^6.0.6",
     "@types/tmp": "^0.2.6",
     "before-build-webpack": "0.2.15",
@@ -27,8 +30,6 @@
     "file-loader": "^6.2.0",
     "html-loader": "2.1.2",
     "html-webpack-plugin": "5.6.7",
-    "sass-embedded": "^1.99.0",
-    "sass-loader": "^16.0.7",
     "jsdom": "^25.0.1",
     "del": "^6.1.1",
     "lodash": "^4.18.1",
@@ -44,6 +45,8 @@
     "get-port": "^5.1.1",
     "puppeteer": "^24.42.0",
     "rimraf": "^5.0.10",
+    "sass-embedded": "^1.99.0",
+    "sass-loader": "^16.0.7",
     "typescript": "^5.9.3"
   },
   "dependencies": {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@rslint/core':
+        specifier: ^0.5.1
+        version: 0.5.2
       '@rspack/cli':
         specifier: 2.0.1
         version: 2.0.1(@rspack/core@2.0.1(@swc/helpers@0.5.21))
@@ -1277,6 +1280,45 @@ packages:
       core-js:
         optional: true
 
+  '@rslint/core@0.5.2':
+    resolution: {integrity: sha512-RDP0uvg0ni1AXl/Jq9LglY8QmSIuM4HN4Lx9Pef6xL1QZrgXkQJ5GKPlBjkbMDu7Zdlfjo1L5D1S0cttaEjBHA==}
+    hasBin: true
+    peerDependencies:
+      jiti: ^2.0.0
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  '@rslint/darwin-arm64@0.5.2':
+    resolution: {integrity: sha512-gu7WyZnyZt9x/TMC+jtf0LYTC0Zq9Fq38utef5dcm8iVbdZNqt+EnwrOqVFaqI1ikYC18IOi9aIe7/bxVZp/aA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rslint/darwin-x64@0.5.2':
+    resolution: {integrity: sha512-sxvIAWldUBd/EeK+PkQhgVbRq6VwHBmUNxKNWyng5zL0gWu02X8ynhyzDgWfUKPXH7BgebSItQBfa4+qFQXhUw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rslint/linux-arm64@0.5.2':
+    resolution: {integrity: sha512-D8cmoMDqzwZqELtxbVZDX0jGMXkSwAejvOL9D1GXoFAxq74xuT/s0UdfbkzZtAAvIFrwa8PGskPXv3X/1w2WbA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rslint/linux-x64@0.5.2':
+    resolution: {integrity: sha512-b4Nato9LgkPX7OydaeXexUUvkfm4+tRAvp46T4xhe76k136/ziImRPBcM/G7pBNyaV5Rd6qp6CiYW330Q+0Gnw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rslint/win32-arm64@0.5.2':
+    resolution: {integrity: sha512-3pfpABHaBv+Z551cKOX+pVllmGFJc7dLHDs2XignLxZ89xsxomlAx8CLhkaDECUkoBM7gj4/oQr57t9Ndhe3Lw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rslint/win32-x64@0.5.2':
+    resolution: {integrity: sha512-MnIp0ofyg7AXP+bgt1VW1ejJszkgyFKHJvSqZ3QePOllWKXA7Nhj4lMIluIcTN1D4C0f00+6POYOeIjSwI+aRQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@rspack/binding-darwin-arm64@1.7.6':
     resolution: {integrity: sha512-NZ9AWtB1COLUX1tA9HQQvWpTy07NSFfKBU8A6ylWd5KH8AePZztpNgLLAVPTuNO4CZXYpwcoclf8jG/luJcQdQ==}
     cpu: [arm64]
@@ -1790,7 +1832,7 @@ packages:
   basic-ftp@5.0.5:
     resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
-    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
+    deprecated: Security vulnerability fixed in 5.2.0, please upgrade
 
   before-build-webpack@0.2.15:
     resolution: {integrity: sha512-mxDxu4PzmZHzLrgtjDQlIIVVaxiwqMtTzKx/Blg3gVCkTRmNPYNtkD7FYfUjyO644ONSEBhHmdY0TCuXV7nvOQ==}
@@ -2423,6 +2465,15 @@ packages:
 
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   file-loader@6.2.0:
     resolution: {integrity: sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==}
@@ -3276,6 +3327,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pify@3.0.0:
     resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
     engines: {node: '>=4'}
@@ -4019,6 +4074,10 @@ packages:
   tiny-lru@8.0.2:
     resolution: {integrity: sha512-ApGvZ6vVvTNdsmt676grvCkUCGwzG9IqXma5Z07xJgiC5L7akUMof5U8G2JTI9Rz/ovtVhJBlY6mNhEvtjzOIg==}
     engines: {node: '>=6'}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
 
   tinypool@2.1.0:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
@@ -4850,6 +4909,36 @@ snapshots:
       core-js: 3.47.0
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
+
+  '@rslint/core@0.5.2':
+    dependencies:
+      picomatch: 4.0.4
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@rslint/darwin-arm64': 0.5.2
+      '@rslint/darwin-x64': 0.5.2
+      '@rslint/linux-arm64': 0.5.2
+      '@rslint/linux-x64': 0.5.2
+      '@rslint/win32-arm64': 0.5.2
+      '@rslint/win32-x64': 0.5.2
+
+  '@rslint/darwin-arm64@0.5.2':
+    optional: true
+
+  '@rslint/darwin-x64@0.5.2':
+    optional: true
+
+  '@rslint/linux-arm64@0.5.2':
+    optional: true
+
+  '@rslint/linux-x64@0.5.2':
+    optional: true
+
+  '@rslint/win32-arm64@0.5.2':
+    optional: true
+
+  '@rslint/win32-x64@0.5.2':
+    optional: true
 
   '@rspack/binding-darwin-arm64@1.7.6':
     optional: true
@@ -6009,6 +6098,10 @@ snapshots:
     dependencies:
       pend: 1.2.0
 
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
   file-loader@6.2.0(webpack@5.106.2):
     dependencies:
       loader-utils: 2.0.4
@@ -6977,6 +7070,8 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.4: {}
+
   pify@3.0.0: {}
 
   pino-std-serializers@2.5.0: {}
@@ -7755,6 +7850,11 @@ snapshots:
   tiny-lru@2.0.0: {}
 
   tiny-lru@8.0.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinypool@2.1.0: {}
 

--- a/rslint.config.ts
+++ b/rslint.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig, js, ts } from '@rslint/core';
+
+export default defineConfig([
+  js.configs.recommended,
+  ts.configs.recommended,
+  {
+    files: ['css-extract/cases/**/expected/**/*.js'],
+    rules: {
+      'no-constant-condition': 'off',
+    },
+  },
+]);


### PR DESCRIPTION
This PR adds Rslint as the repository lint entrypoint. It includes `rslint.config.ts`, the `@rslint/core` dev dependency, a VS Code extension recommendation, and a GitHub Actions lint workflow that runs `pnpm run lint`.

A few simple Rslint findings were fixed directly; the remaining generated-code exception is captured in the Rslint config. Validated locally with `pnpm run lint`.
