### PR TITLE
Update output module html plugin test

### DIFF
--- a/html-plugin/basic.test.js
+++ b/html-plugin/basic.test.js
@@ -3603,7 +3603,7 @@ describe("HtmlWebpackPlugin", () => {
         experiments: { outputModule: true },
         plugins: [new HtmlWebpackPlugin({})],
       },
-      ['<script defer src="index_bundle.js"></script>'],
+      ['<script src="index_bundle.js" type="module"></script>'],
       null,
     );
   });


### PR DESCRIPTION
## Summary

Update the html plugin test expectation for `experiments: { outputModule: true }` to match the current Rspack output.

When `output.module` is enabled, Rspack now emits the script tag as a module script:

```html
<script src="index_bundle.js" type="module"></script>
