### PR TITLE
Stabilize css-extract test cleanup

### DIFF
--- a/css-extract/TestCases.test.js
+++ b/css-extract/TestCases.test.js
@@ -11,26 +11,12 @@ const { CssExtractRspackPlugin } = webpack;
 const UPDATE_TEST = process.env.UPDATE_SNAPSHOT === "true";
 
 function clearDirectory(dirPath) {
-	let files;
-
-	try {
-		files = fs.readdirSync(dirPath);
-	} catch (e) {
-		return;
-	}
-	if (files.length > 0) {
-		for (let i = 0; i < files.length; i++) {
-			const filePath = `${dirPath}/${files[i]}`;
-
-			if (fs.statSync(filePath).isFile()) {
-				fs.unlinkSync(filePath);
-			} else {
-				clearDirectory(filePath);
-			}
-		}
-	}
-
-	fs.rmdirSync(dirPath);
+	fs.rmSync(dirPath, {
+		recursive: true,
+		force: true,
+		maxRetries: 5,
+		retryDelay: 100,
+	});
 }
 
 const hashRE = /(.*)\.\$.*\$\.(.*)/;


### PR DESCRIPTION
## Summary

- Replace the hand-rolled recursive cleanup for `css-extract/js` with `fs.rmSync` using recursive, forced deletion.
- Add retry handling for transient `ENOTEMPTY` failures during output directory cleanup.

## Root Cause

The previous cleanup walked the directory tree manually and then called `fs.rmdirSync`. On Linux CI, the output directory can still contain files by the time the final `rmdirSync` runs, which caused the ecosystem CI failure:

`ENOTEMPTY: directory not empty, rmdir .../css-extract/js`

## Validation

- `corepack pnpm@11.6.0 exec rstest css-extract/TestCases.test.js`
- `corepack pnpm@11.6.0 run lint`
- `corepack pnpm@11.6.0 exec rstest css-extract/TestCases.test.js` repeated 5 times