### PR TITLE
fix: isolate css-extract test output directories

### DIFF
--- a/css-extract/TestCache.test.js
+++ b/css-extract/TestCache.test.js
@@ -7,6 +7,8 @@ import { createRequire } from "module";
 const require = createRequire(import.meta.url);
 
 describe("TestCache", () => {
+	const outputRoot = path.resolve(import.meta.dirname, "js", "test-cache");
+
 	afterEach(() => {
 		rstest.clearAllMocks();
 	});
@@ -19,7 +21,7 @@ describe("TestCache", () => {
 			directoryForCase,
 			"webpack.config.mjs"
 		))).default;
-		const outputPath = path.resolve(import.meta.dirname, "js/cache-false");
+		const outputPath = path.resolve(outputRoot, "cache-false");
 
 		await del([outputPath]);
 
@@ -119,7 +121,7 @@ describe("TestCache", () => {
 			directoryForCase,
 			"webpack.config.mjs"
 		))).default;
-		const outputPath = path.resolve(import.meta.dirname, "js/cache-memory");
+		const outputPath = path.resolve(outputRoot, "cache-memory");
 
 		await del([outputPath]);
 
@@ -219,10 +221,11 @@ describe("TestCache", () => {
 			directoryForCase,
 			"webpack.config.mjs"
 		))).default;
-		const outputPath = path.resolve(import.meta.dirname, "js/cache-filesystem");
+		const outputPath = path.resolve(outputRoot, "cache-filesystem");
 		const fileSystemCacheDirectory = path.resolve(
-			import.meta.dirname,
-			"./js/.cache/type-filesystem"
+			outputRoot,
+			".cache",
+			"type-filesystem"
 		);
 
 		await del([outputPath, fileSystemCacheDirectory]);
@@ -327,10 +330,11 @@ describe("TestCache", () => {
 			directoryForCase,
 			"webpack.config.mjs"
 		))).default;
-		const outputPath = path.resolve(import.meta.dirname, "js/cache-filesystem-1");
+		const outputPath = path.resolve(outputRoot, "cache-filesystem-1");
 		const fileSystemCacheDirectory = path.resolve(
-			import.meta.dirname,
-			"./js/.cache/type-filesystem-1"
+			outputRoot,
+			".cache",
+			"type-filesystem-1"
 		);
 
 		await del([outputPath, fileSystemCacheDirectory]);
@@ -433,12 +437,13 @@ describe("TestCache", () => {
 			"webpack.config.mjs"
 		))).default;
 		const outputPath = path.resolve(
-			import.meta.dirname,
-			"js/cache-filesystem-asset-modules"
+			outputRoot,
+			"cache-filesystem-asset-modules"
 		);
 		const fileSystemCacheDirectory = path.resolve(
-			import.meta.dirname,
-			"./js/.cache/type-filesystem"
+			outputRoot,
+			".cache",
+			"type-filesystem"
 		);
 
 		await del([outputPath, fileSystemCacheDirectory]);
@@ -544,12 +549,13 @@ describe("TestCache", () => {
 			"webpack.config.mjs"
 		))).default;
 		const outputPath = path.resolve(
-			import.meta.dirname,
-			"js/cache-filesystem-file-loader"
+			outputRoot,
+			"cache-filesystem-file-loader"
 		);
 		const fileSystemCacheDirectory = path.resolve(
-			import.meta.dirname,
-			"./js/.cache/type-filesystem"
+			outputRoot,
+			".cache",
+			"type-filesystem"
 		);
 
 		await del([outputPath, fileSystemCacheDirectory]);

--- a/css-extract/TestCases.test.js
+++ b/css-extract/TestCases.test.js
@@ -161,7 +161,7 @@ function compareDirectory(actual, expected, webpackStats) {
 
 describe("TestCases", () => {
 	const casesDirectory = path.resolve(import.meta.dirname, "cases");
-	const outputDirectory = path.resolve(import.meta.dirname, "js");
+	const outputDirectory = path.resolve(import.meta.dirname, "js", "test-cases");
 	const tests = fs.readdirSync(casesDirectory).filter(test => test !== "package.json").filter(test => {
 		const testDirectory = path.join(casesDirectory, test);
 		const filterPath = path.join(testDirectory, "test.filter.js");

--- a/css-extract/attributesOption.test.js
+++ b/css-extract/attributesOption.test.js
@@ -13,6 +13,8 @@ import {
 } from "./helpers/index.js";
 
 describe("attributes option", () => {
+	const outputRoot = path.resolve(import.meta.dirname, "js", "attributes-option");
+
 	it(`should work without attributes option`, async () => {
 		const compiler = getCompiler(
 			"attributes.js",
@@ -20,7 +22,7 @@ describe("attributes option", () => {
 			{
 				output: {
 					publicPath: "",
-					path: path.resolve(import.meta.dirname, "../outputs"),
+					path: outputRoot,
 					filename: "[name].bundle.js"
 				},
 				plugins: [
@@ -48,7 +50,7 @@ describe("attributes option", () => {
 			{
 				output: {
 					publicPath: "",
-					path: path.resolve(import.meta.dirname, "../outputs"),
+					path: outputRoot,
 					filename: "[name].bundle.js"
 				},
 				plugins: [

--- a/css-extract/emitOption.test.js
+++ b/css-extract/emitOption.test.js
@@ -16,6 +16,8 @@ import {
 } from "./helpers/index";
 
 describe("emit option", () => {
+	const outputRoot = path.resolve(import.meta.dirname, "js", "emit-option");
+
 	it('should work without emit option', async () => {
 		const compiler = getCompiler(
 			"style-url.js",
@@ -23,7 +25,7 @@ describe("emit option", () => {
 			{
 				mode: "none",
 				output: {
-					path: path.resolve(import.meta.dirname, "../outputs"),
+					path: outputRoot,
 					filename: "[name].bundle.js"
 				},
 
@@ -52,7 +54,7 @@ describe("emit option", () => {
 			{
 				mode: "none",
 				output: {
-					path: path.resolve(import.meta.dirname, "../outputs")
+					path: outputRoot
 				},
 
 				plugins: [
@@ -80,7 +82,7 @@ describe("emit option", () => {
 			{
 				mode: "none",
 				output: {
-					path: path.resolve(import.meta.dirname, "../outputs")
+					path: outputRoot
 				},
 				plugins: [
 					new MiniCssExtractPlugin({
@@ -104,7 +106,7 @@ describe("emit option", () => {
 			{},
 			{
 				output: {
-					path: path.resolve(import.meta.dirname, "../outputs"),
+					path: outputRoot,
 					filename: "[name].bundle.js"
 				},
 				module: {
@@ -171,7 +173,7 @@ describe("emit option", () => {
 			}
 		}
 
-		const outputPath = path.resolve(import.meta.dirname, "./js/cache-memory");
+		const outputPath = path.resolve(outputRoot, "cache-memory");
 		const webpackConfig = {
 			mode: "development",
 			context: path.resolve(import.meta.dirname, "./fixtures"),
@@ -280,7 +282,7 @@ describe("emit option", () => {
 	});
 
 	it('should work with the "memory" cache and disabled "emit" option', async () => {
-		const outputPath = path.resolve(import.meta.dirname, "./js/cache-memory");
+		const outputPath = path.resolve(outputRoot, "cache-memory");
 		const webpackConfig = {
 			mode: "development",
 			context: path.resolve(import.meta.dirname, "fixtures"),
@@ -394,7 +396,7 @@ describe("emit option", () => {
 			}
 		}
 
-		const outputPath = path.resolve(import.meta.dirname, "./js/cache-memory");
+		const outputPath = path.resolve(outputRoot, "cache-memory");
 		const modifyAsset = path.resolve(import.meta.dirname, "fixtures", "style-url.css");
 		const modifyAssetContent = fs.readFileSync(modifyAsset);
 		const webpackConfig = {

--- a/css-extract/helpers/getCompiler.js
+++ b/css-extract/helpers/getCompiler.js
@@ -11,7 +11,7 @@ export default (fixture, loaderOptions = {}, config = {}) => {
 		context: path.resolve(import.meta.dirname, "../fixtures"),
 		entry: path.resolve(import.meta.dirname, "../fixtures", fixture),
 		output: {
-			path: path.resolve(import.meta.dirname, "../outputs"),
+			path: path.resolve(import.meta.dirname, "..", "js", "helpers"),
 			filename: "[name].bundle.js",
 			chunkFilename: "[name].chunk.js"
 		},

--- a/css-extract/ignoreOrderOption.test.js
+++ b/css-extract/ignoreOrderOption.test.js
@@ -5,6 +5,8 @@ import { describe, expect, it } from "@rstest/core";
 const require = createRequire(import.meta.url);
 
 describe("IgnoreOrder", () => {
+	const outputRoot = path.resolve(import.meta.dirname, "js", "ignore-order");
+
 	it("should emit warnings", async () => {
 		const casesDirectory = path.resolve(import.meta.dirname, "cases");
 		const directoryForCase = path.resolve(casesDirectory, "ignoreOrderFalse");
@@ -16,7 +18,7 @@ describe("IgnoreOrder", () => {
 		const compiler = webpack({
 			...webpackConfig,
 			output: {
-				path: path.join(import.meta.dirname, "js", "ignoreOrderTest", "ignoreOrderFalse")
+				path: path.join(outputRoot, "ignoreOrderFalse")
 			},
 			mode: "development",
 			context: directoryForCase,
@@ -44,7 +46,7 @@ describe("IgnoreOrder", () => {
 		const compiler = webpack({
 			...webpackConfig,
 			output: {
-				path: path.join(import.meta.dirname, "js", "ignoreOrderTest", "ignoreOrder")
+				path: path.join(outputRoot, "ignoreOrder")
 			},
 			mode: "development",
 			context: directoryForCase,

--- a/css-extract/insertOption.test.js
+++ b/css-extract/insertOption.test.js
@@ -13,6 +13,8 @@ import {
 } from "./helpers/index";
 
 describe("insert option", () => {
+	const outputRoot = path.resolve(import.meta.dirname, "js", "insert-option");
+
 	it(`should work without insert option`, async () => {
 		const compiler = getCompiler(
 			"insert.js",
@@ -21,7 +23,7 @@ describe("insert option", () => {
 				mode: "none",
 				output: {
 					publicPath: "",
-					path: path.resolve(import.meta.dirname, "../outputs"),
+					path: outputRoot,
 					filename: "[name].bundle.js"
 				},
 				plugins: [
@@ -49,7 +51,7 @@ describe("insert option", () => {
 				mode: "none",
 				output: {
 					publicPath: "",
-					path: path.resolve(import.meta.dirname, "../outputs"),
+					path: outputRoot,
 					filename: "[name].bundle.js"
 				},
 				plugins: [
@@ -78,7 +80,7 @@ describe("insert option", () => {
 				mode: "none",
 				output: {
 					publicPath: "",
-					path: path.resolve(import.meta.dirname, "../outputs"),
+					path: outputRoot,
 					filename: "[name].bundle.js"
 				},
 				plugins: [

--- a/css-extract/linkTagOption.test.js
+++ b/css-extract/linkTagOption.test.js
@@ -11,6 +11,8 @@ import {
 } from "./helpers/index.js";
 
 describe("linkType option", () => {
+	const outputRoot = path.resolve(import.meta.dirname, "js", "link-tag-option");
+
 	it(`should work without linkType option`, async () => {
 		const compiler = getCompiler(
 			"attributes.js",
@@ -18,7 +20,7 @@ describe("linkType option", () => {
 			{
 				output: {
 					publicPath: "",
-					path: path.resolve(import.meta.dirname, "../outputs"),
+					path: outputRoot,
 					filename: "[name].bundle.js"
 				},
 				plugins: [
@@ -45,7 +47,7 @@ describe("linkType option", () => {
 			{
 				output: {
 					publicPath: "",
-					path: path.resolve(import.meta.dirname, "../outputs"),
+					path: outputRoot,
 					filename: "[name].bundle.js"
 				},
 				plugins: [
@@ -73,7 +75,7 @@ describe("linkType option", () => {
 			{
 				output: {
 					publicPath: "",
-					path: path.resolve(import.meta.dirname, "../outputs"),
+					path: outputRoot,
 					filename: "[name].bundle.js"
 				},
 				plugins: [

--- a/css-extract/runtimeOption.test.js
+++ b/css-extract/runtimeOption.test.js
@@ -11,6 +11,8 @@ import {
 } from "./helpers/index.js";
 
 describe("noRuntime option", () => {
+	const outputRoot = path.resolve(import.meta.dirname, "js", "runtime-option");
+
 	it.only("should work without the 'runtime' option", async () => {
 		const compiler = getCompiler(
 			"attributes.js",
@@ -18,7 +20,7 @@ describe("noRuntime option", () => {
 			{
 				output: {
 					publicPath: "",
-					path: path.resolve(import.meta.dirname, "../outputs"),
+					path: outputRoot,
 					filename: "[name].bundle.js"
 				},
 				plugins: [
@@ -47,7 +49,7 @@ describe("noRuntime option", () => {
 			{
 				output: {
 					publicPath: "",
-					path: path.resolve(import.meta.dirname, "../outputs"),
+					path: outputRoot,
 					filename: "[name].bundle.js"
 				},
 				plugins: [
@@ -79,7 +81,7 @@ describe("noRuntime option", () => {
 			{
 				output: {
 					publicPath: "",
-					path: path.resolve(import.meta.dirname, "../outputs"),
+					path: outputRoot,
 					filename: "[name].bundle.js"
 				},
 				plugins: [


### PR DESCRIPTION
## Summary

- Move css-extract case outputs under `css-extract/js/test-cases`
- Give css-extract cache, emit, ignore-order, and option tests their own output roots
- Update the css-extract helper default output path to `css-extract/js/helpers`
