### PR TITLE
chore: bump Rspack for `output.module` HTML behavior

### DIFF
--- a/html-plugin/basic.test.js
+++ b/html-plugin/basic.test.js
@@ -3590,7 +3590,7 @@ describe("HtmlWebpackPlugin", () => {
     );
   });
 
-  it("should allow to use experiments:{outputModule:true}", async () => {
+  it("should allow to use output:{module:true}", async () => {
     await testHtmlPlugin(
       {
         mode: "production",
@@ -3600,7 +3600,6 @@ describe("HtmlWebpackPlugin", () => {
           filename: "index_bundle.js",
           module: true,
         },
-        experiments: { outputModule: true },
         plugins: [new HtmlWebpackPlugin({})],
       },
       ['<script src="index_bundle.js" type="module"></script>'],

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   "repository": "web-infra-dev/rspack-plugin-ci",
   "devDependencies": {
     "@rslint/core": "^0.6.1",
-    "@rspack/cli": "2.0.8",
-    "@rspack/core": "2.0.8",
+    "@rspack/cli": "2.1.1",
+    "@rspack/core": "2.1.1",
     "@rstest/core": "^0.10.4",
     "@types/connect": "^3.4.38",
     "@types/cross-spawn": "^6.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,10 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@rspack/cli': npm:@rspack-canary/cli@2.1.0-canary-d00c9279-20260622184513
-  '@rspack/core': npm:@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513
-
 importers:
 
   .:
@@ -16,11 +12,11 @@ importers:
         specifier: ^0.6.1
         version: 0.6.1
       '@rspack/cli':
-        specifier: npm:@rspack-canary/cli@2.1.0-canary-d00c9279-20260622184513
-        version: '@rspack-canary/cli@2.1.0-canary-d00c9279-20260622184513(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))'
+        specifier: 2.1.1
+        version: 2.1.1(@rspack/core@2.1.1(@swc/helpers@0.5.23))
       '@rspack/core':
-        specifier: npm:@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513
-        version: '@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23)'
+        specifier: 2.1.1
+        version: 2.1.1(@swc/helpers@0.5.23)
       '@rstest/core':
         specifier: ^0.10.4
         version: 0.10.4(jsdom@25.0.1)
@@ -50,7 +46,7 @@ importers:
         version: 7.0.6
       css-loader:
         specifier: ^7.1.4
-        version: 7.1.4(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 7.1.4(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       del:
         specifier: ^6.1.1
         version: 6.1.1
@@ -77,7 +73,7 @@ importers:
         version: 2.1.2(webpack@5.98.0)
       html-webpack-plugin:
         specifier: 5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1
@@ -98,7 +94,7 @@ importers:
         version: 1.100.0
       sass-loader:
         specifier: ^16.0.8
-        version: 16.0.8(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.98.0)
+        version: 16.0.8(@rspack/core@2.1.1(@swc/helpers@0.5.23))(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.98.0)
       tmp:
         specifier: ^0.2.5
         version: 0.2.5
@@ -131,7 +127,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -152,7 +148,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -167,7 +163,7 @@ importers:
     devDependencies:
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -182,7 +178,7 @@ importers:
     devDependencies:
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -200,7 +196,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -215,7 +211,7 @@ importers:
     devDependencies:
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -230,7 +226,7 @@ importers:
     devDependencies:
       css-loader:
         specifier: ^7.1.4
-        version: 7.1.4(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 7.1.4(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       css-select:
         specifier: ^5.2.2
         version: 5.2.2
@@ -239,7 +235,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       htmlparser2:
         specifier: ^8.0.2
         version: 8.0.2
@@ -266,10 +262,10 @@ importers:
         version: 26.6.2
       html-webpack-externals-plugin:
         specifier: ^3.8.0
-        version: 3.8.0(html-webpack-plugin@5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0))
+        version: 3.8.0(html-webpack-plugin@5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0))
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       htmlparser2:
         specifier: ^8.0.2
         version: 8.0.2
@@ -293,7 +289,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       htmlparser2:
         specifier: ^8.0.2
         version: 8.0.2
@@ -317,7 +313,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       htmlparser2:
         specifier: ^8.0.2
         version: 8.0.2
@@ -341,7 +337,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       htmlparser2:
         specifier: ^8.0.2
         version: 8.0.2
@@ -359,13 +355,13 @@ importers:
     devDependencies:
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
       script-ext-html-webpack-plugin:
         specifier: ^2.1.5
-        version: 2.1.5(html-webpack-plugin@5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0))(webpack@5.98.0)
+        version: 2.1.5(html-webpack-plugin@5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0))(webpack@5.98.0)
       webpack:
         specifier: 5.98.0
         version: 5.98.0(webpack-cli@5.1.4)
@@ -392,13 +388,13 @@ importers:
     devDependencies:
       css-loader:
         specifier: ^7.1.4
-        version: 7.1.4(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 7.1.4(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       expect:
         specifier: ^26.6.2
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       mini-css-extract-plugin:
         specifier: ^1.6.2
         version: 1.6.2(webpack@5.98.0)
@@ -419,7 +415,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -434,7 +430,7 @@ importers:
     devDependencies:
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -452,7 +448,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -470,7 +466,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -488,7 +484,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -506,7 +502,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -521,7 +517,7 @@ importers:
     devDependencies:
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -536,10 +532,10 @@ importers:
     devDependencies:
       css-loader:
         specifier: ^7.1.4
-        version: 7.1.4(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 7.1.4(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       mini-css-extract-plugin:
         specifier: ^1.6.2
         version: 1.6.2(webpack@5.98.0)
@@ -560,7 +556,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -578,7 +574,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -596,7 +592,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -614,7 +610,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -632,7 +628,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -650,7 +646,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -668,7 +664,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -683,7 +679,7 @@ importers:
     devDependencies:
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -704,7 +700,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -722,7 +718,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -740,13 +736,13 @@ importers:
     devDependencies:
       css-loader:
         specifier: ^7.1.4
-        version: 7.1.4(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 7.1.4(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       expect:
         specifier: ^26.6.2
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       mini-css-extract-plugin:
         specifier: ^1.6.2
         version: 1.6.2(webpack@5.98.0)
@@ -770,7 +766,7 @@ importers:
     devDependencies:
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -785,7 +781,7 @@ importers:
     devDependencies:
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -800,13 +796,13 @@ importers:
     devDependencies:
       css-loader:
         specifier: ^7.1.4
-        version: 7.1.4(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 7.1.4(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       expect:
         specifier: ^26.6.2
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       mini-css-extract-plugin:
         specifier: ^1.6.2
         version: 1.6.2(webpack@5.98.0)
@@ -927,11 +923,20 @@ packages:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
@@ -1132,6 +1137,12 @@ packages:
     peerDependencies:
       tslib: '2'
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@napi-rs/wasm-runtime@1.1.5':
     resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
     peerDependencies:
@@ -1313,64 +1324,132 @@ packages:
   '@rslint/native@0.6.1':
     resolution: {integrity: sha512-WR/tITtBCjxkBhpDRip4h6n+gxMMqqijFKmDjuc3O/ScWMrX+KbeKcnS0u1Y8e0YfoAmk7dHR9HIT+IRHod1IQ==}
 
-  '@rspack-canary/binding-darwin-arm64@2.1.0-canary-d00c9279-20260622184513':
-    resolution: {integrity: sha512-XbBk0ufT9xXgIz1M6gm8BQZ+8rFEBR7BKgDZwtYorkEy5k4eCzaSEJN9qXN1XN3SQjz4cbxXCAwamOFRYYjNQA==}
+  '@rspack/binding-darwin-arm64@2.0.8':
+    resolution: {integrity: sha512-vCgbgH7B7qom+uID+RCZsTCOYFb9wC4/4+1U6rMfytrXGVJ72eNQs2tbdjOl0lb18CT3N/n+VkWynUiLk84GwA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack-canary/binding-darwin-x64@2.1.0-canary-d00c9279-20260622184513':
-    resolution: {integrity: sha512-jhct3NuC04odZcbOZFpal/Qpsihp3Fa+opBl4AGsbUOLG7VDa6OfGMzPpQCUQUJ7lz2JN2vD+oWLO6I2ZFi86w==}
+  '@rspack/binding-darwin-arm64@2.1.1':
+    resolution: {integrity: sha512-6K8jA3pZphBwLt5DU78wl0IzY1myHrqNSvFVCd9CHa+szlOwv2iMQpZdYdpupIBxwiZ39rrDyQKtoZw7lsAG8w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@2.0.8':
+    resolution: {integrity: sha512-satPm2PD4B7jDTVlVAdvMVdUszwLvWUEnUDzLb77mvVkezKNDZmuhb+e8s+FfKs8hJpNbZ9VAejuA2rr8o985w==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack-canary/binding-linux-arm64-gnu@2.1.0-canary-d00c9279-20260622184513':
-    resolution: {integrity: sha512-jcv99f3yGpE4jtezgcRQ8s1iJ/bFCZIXtZ8mAQKTCkOnDSKLCgXk1TUav+I2/O3F5e9ofTTt5Xf900RK5Obgrw==}
+  '@rspack/binding-darwin-x64@2.1.1':
+    resolution: {integrity: sha512-RdqtEfIbSe5ucLNVvMac1k88UwmL4Gil8uXqlEFcSZ3VC2jTOkecadd+B0RYqJ+PirSInrRmKm1cr0740zppOA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-linux-arm64-gnu@2.0.8':
+    resolution: {integrity: sha512-pSI+npPQE/uDtiboqvcOIRJbEV2+B+H1xffmko/gw50la92oTUW60kVULFwsb6L0+GVCzIcwX3yq60GtYIn+Ug==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack-canary/binding-linux-arm64-musl@2.1.0-canary-d00c9279-20260622184513':
-    resolution: {integrity: sha512-fMiAFIm0QcnB3isGdBspFDleZxvZFUsnWyEmDW8TRwoAY6ae9DQs3FmckGb3cEoYZxp1XhT2g7m3hr5cZ6v35A==}
+  '@rspack/binding-linux-arm64-gnu@2.1.1':
+    resolution: {integrity: sha512-ROKtqXoLpbZO1vYEcNxQg6COvRhdlJcoib1Z4pzG1nIyctEAUuFmnD7pIvJiVe6M7YuJNXW+1p0BhpptT2XEUQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-arm64-musl@2.0.8':
+    resolution: {integrity: sha512-igjJ43yxWQ72GZqjDDZSSHax9/Vg+6rLMmOvFglTJUkQpB4Tyvu/YjW+WRjYj2xRw6blOjLxUSJWASvuSqqlvg==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rspack-canary/binding-linux-x64-gnu@2.1.0-canary-d00c9279-20260622184513':
-    resolution: {integrity: sha512-qqcGwiKQNcGipNsfUAHkvDtAtNvk7wxCVbxbo3jVYhUe9+w6YEWmDJHvEH87UqTnY5OZwhXf4pwAU9yJIB8WCA==}
+  '@rspack/binding-linux-arm64-musl@2.1.1':
+    resolution: {integrity: sha512-QdQpG9dK0GfPASjBd/8rUwDNW0ShfFfYJfcoGLNTM6A8EqmgvWwklXDiCVF5dXALbZIksAuRznIKnLDsUoXi9Q==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-linux-riscv64-gnu@2.1.1':
+    resolution: {integrity: sha512-LGdYCAvblZp2qtHk9UseYftIRyaBzSWqEzd1toaS08sYESXERm+YBbrYKKiyq1yXiU1L7BkhMUxiWc3GCYmKcA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-riscv64-musl@2.1.1':
+    resolution: {integrity: sha512-87phiiPGFT1p4gy3Oz6YdNijCPXdjJy43LFdE8AFiZsV4ChFXQPqnVCF2aMRLybYa51A+9wGYlTvxt09yUQUww==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-linux-x64-gnu@2.0.8':
+    resolution: {integrity: sha512-zrkoEOnqj1hOEBO5T2I/2Ts2HSJsYFh1qXwMpK4dMJFGGNWDfNeUa6/LF5uq3VINF3JUl7RL47AgrucoSZJXPA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack-canary/binding-linux-x64-musl@2.1.0-canary-d00c9279-20260622184513':
-    resolution: {integrity: sha512-n8XumZH2o+AYlgy42G6fYsJT5Aol7Tq3W7zsPf82SBqpgrV8hc21xi9dRkVh6WDQPEUDvaSOLS2Acxrdy5y4tA==}
+  '@rspack/binding-linux-x64-gnu@2.1.1':
+    resolution: {integrity: sha512-om0/PvZzxISsnyz3hdmI3xBi3Qsn6faRGrfp6WJpGHa5JYYaRVWz1MJ9fe+/cQE9ON9r32HpMOeuataCLv+Owg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-x64-musl@2.0.8':
+    resolution: {integrity: sha512-6CtDaGZjNDvJd9TBp7a9zABbrPORO21W96+3ZcGBn0YNUPUk4ARxIxrTTpeJ/1F41QDM8AYIkGDdqEYMqTYBsA==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rspack-canary/binding-wasm32-wasi@2.1.0-canary-d00c9279-20260622184513':
-    resolution: {integrity: sha512-RXsPi3Yswm8vxZmhZ9r43r1XIa05CsW2PkECGaZiq1hsm7RAEfoAiH7l+azHcVhObdEgW6ezqM6L/c79jduUeQ==}
+  '@rspack/binding-linux-x64-musl@2.1.1':
+    resolution: {integrity: sha512-YgAyTOM5ZWvWT0Exwcg7QkGUv9PsHT4yIsEyJbH+a99uAKliGMwkHIOP/aJgrCF8G+lTfigY2wyl9cWo4TA4aw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-wasm32-wasi@2.0.8':
+    resolution: {integrity: sha512-Yf4SiqTUroT5Ju+te0YAY2xxKOb35tECsO21v7hYyGa705wrgoAK/MmF7enOvs9GR1iZIqgiLD/wxsIxl8GjJw==}
     cpu: [wasm32]
 
-  '@rspack-canary/binding-win32-arm64-msvc@2.1.0-canary-d00c9279-20260622184513':
-    resolution: {integrity: sha512-o1l1FESIJu1ZyYzOEOtfgyM7GB/0wveK1JeZbJhvvp933BKENW/1cDxt526Zk9EuUNJ7JbAAkn13CruseXfKeQ==}
+  '@rspack/binding-wasm32-wasi@2.1.1':
+    resolution: {integrity: sha512-OicgaB3Dcd+KXsH/I3DkJG7XQyREJScg/jLkCtycFn9BhT0IVJvgi37F8QNJKl8Bp9YZIGehsqK9HpQWav6SLw==}
+    cpu: [wasm32]
+
+  '@rspack/binding-win32-arm64-msvc@2.0.8':
+    resolution: {integrity: sha512-8NCuiQsAhXrwRBy57QZoypqrws/zLBkaQVGiB8hksr6v++8hNigNjqpQARLbd0iyMuHsQQ++8+auGk6xlDXmzw==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack-canary/binding-win32-ia32-msvc@2.1.0-canary-d00c9279-20260622184513':
-    resolution: {integrity: sha512-oBZnWYXRrLCf1209P0/DTZQXpOklJgkEo+bjAKKq5+FZGe0zPvlXbA4Snu4zQeF+IOltPVQfikjiS35WzQYWzQ==}
+  '@rspack/binding-win32-arm64-msvc@2.1.1':
+    resolution: {integrity: sha512-fwL4P3SsC0r/vVGgnmexnc4vkvf+9vWMcGw5fdlPBJNR/zWlZRSXR5V6eXcHrpYVLhBsLYvZYE3NZa9paIUGxw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-ia32-msvc@2.0.8':
+    resolution: {integrity: sha512-bxiekytbX7V9KFAra+HkwtNWC6pYfHEBBZFpiT0xUs3mCFOmAAFVBsBSQsoCP9AdCEXoMAvNdnrHNw3iov4OZw==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack-canary/binding-win32-x64-msvc@2.1.0-canary-d00c9279-20260622184513':
-    resolution: {integrity: sha512-TBV7AFmeyG546ci3NRUhp5NrDnTfWejZsjZK947qbBSiHabxMCc5PvBncf3LMr4l/CXWapGldHlkY4uWDt3mUg==}
+  '@rspack/binding-win32-ia32-msvc@2.1.1':
+    resolution: {integrity: sha512-j3BISXbjPyI57HeHxW9Jx+UP7RebNQ4t62uCbRP29caf9aghYJP+ZA5nJ2X7pol7N5Je2/V6WNahuNd0zQFDOA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rspack/binding-win32-x64-msvc@2.0.8':
+    resolution: {integrity: sha512-7zPs8YCe/ZVJTwd+5lpB0CP0tkn2pONf/T1ycmVY76u21Nrwt8mXQGc/2yH2eWP4B7fikYBr3hGr7mpR2fajqQ==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack-canary/binding@2.1.0-canary-d00c9279-20260622184513':
-    resolution: {integrity: sha512-G8dCDd+l4C2Y2zkhcyjRpJa6MNnUP3E8bfos4cH3MrRoPRq5DtpFT7jXsTI4WoXEUtihImg7QcqbhgZqUHZexQ==}
+  '@rspack/binding-win32-x64-msvc@2.1.1':
+    resolution: {integrity: sha512-aPNNFuZT5iBM8+S9J4P5ywJbf3tUvZN3Ppe6mXJ8/jTVDUDhe0YVj3AgD/AuxnUvl+yHrLfQkN1nNwUfIcomfA==}
+    cpu: [x64]
+    os: [win32]
 
-  '@rspack-canary/cli@2.1.0-canary-d00c9279-20260622184513':
-    resolution: {integrity: sha512-yHm03slWFwUK0gOVk4LiimNiRD7gREoWlAhGb0MhQ9cPX/rvKdYefCeHYOMxa5EafZqmN5N/rjr8o78pXm4C2w==}
+  '@rspack/binding@2.0.8':
+    resolution: {integrity: sha512-3uZ+y8aQxq33ty2srMxg2Nu0XuBI6vVrG50rkDaXqwWqOohfgGUSfFuQK7EnSUNy4aFUQlCG6NHialQHJov0wg==}
+
+  '@rspack/binding@2.1.1':
+    resolution: {integrity: sha512-6062hZP33fn1w51ClpQnum19GGXl/3eS754xrRYbQ7wwBNZk94HVwfSyiqcNCtY/pB1lsFjnaTKiW/Q+jv0axQ==}
+
+  '@rspack/cli@2.1.1':
+    resolution: {integrity: sha512-zsJFurwCDesy0dud7cejObagbbXsvKcQ6j485nmnytBsXV17Uf6XfedQMxnOXBZeGIel+I7Jl/Jp3Sn08TsZuw==}
     hasBin: true
     peerDependencies:
       '@rspack/core': ^2.0.0-0
@@ -1379,8 +1458,20 @@ packages:
       '@rspack/dev-server':
         optional: true
 
-  '@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513':
-    resolution: {integrity: sha512-cmMPeT0CKgOsin9M4EpoCtM8vSuK2QNauBGatL1/BJUK6K01rHzfv3MTp/5cB7vM1lz7q5hNmKC4eEJfhQOwvg==}
+  '@rspack/core@2.0.8':
+    resolution: {integrity: sha512-+NLGJf8gZxihDmMFzjlly3toc2SMjeDmuvz0/Cai9AMdV4F+Pqcnt2BA9V4e3SY2jmhJQtPwgyyLtR1RiJO77g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': ^0.5.23
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@2.1.1':
+    resolution: {integrity: sha512-Rgz6xZcD0rm7ejZhYNi13qvW2dSnIQQt/7D3xbYoT5hOU838JbkF0P3SAMFGKE+FyLZswnyRpxGfnYHZQqDmJA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -4307,13 +4398,29 @@ snapshots:
 
   '@discoveryjs/json-ext@0.5.7': {}
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -4547,6 +4654,13 @@ snapshots:
       '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
       tslib: 2.8.1
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
   '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@emnapi/core': 1.11.1
@@ -4645,7 +4759,7 @@ snapshots:
 
   '@rsbuild/core@2.0.14':
     dependencies:
-      '@rspack/core': '@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23)'
+      '@rspack/core': 2.0.8(@swc/helpers@0.5.23)
       '@swc/helpers': 0.5.23
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -4699,60 +4813,121 @@ snapshots:
       '@rslint/native-win32-arm64-msvc': 0.6.1
       '@rslint/native-win32-x64-msvc': 0.6.1
 
-  '@rspack-canary/binding-darwin-arm64@2.1.0-canary-d00c9279-20260622184513':
+  '@rspack/binding-darwin-arm64@2.0.8':
     optional: true
 
-  '@rspack-canary/binding-darwin-x64@2.1.0-canary-d00c9279-20260622184513':
+  '@rspack/binding-darwin-arm64@2.1.1':
     optional: true
 
-  '@rspack-canary/binding-linux-arm64-gnu@2.1.0-canary-d00c9279-20260622184513':
+  '@rspack/binding-darwin-x64@2.0.8':
     optional: true
 
-  '@rspack-canary/binding-linux-arm64-musl@2.1.0-canary-d00c9279-20260622184513':
+  '@rspack/binding-darwin-x64@2.1.1':
     optional: true
 
-  '@rspack-canary/binding-linux-x64-gnu@2.1.0-canary-d00c9279-20260622184513':
+  '@rspack/binding-linux-arm64-gnu@2.0.8':
     optional: true
 
-  '@rspack-canary/binding-linux-x64-musl@2.1.0-canary-d00c9279-20260622184513':
+  '@rspack/binding-linux-arm64-gnu@2.1.1':
     optional: true
 
-  '@rspack-canary/binding-wasm32-wasi@2.1.0-canary-d00c9279-20260622184513':
+  '@rspack/binding-linux-arm64-musl@2.0.8':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@2.1.1':
+    optional: true
+
+  '@rspack/binding-linux-riscv64-gnu@2.1.1':
+    optional: true
+
+  '@rspack/binding-linux-riscv64-musl@2.1.1':
+    optional: true
+
+  '@rspack/binding-linux-x64-gnu@2.0.8':
+    optional: true
+
+  '@rspack/binding-linux-x64-gnu@2.1.1':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.0.8':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.1.1':
+    optional: true
+
+  '@rspack/binding-wasm32-wasi@2.0.8':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rspack/binding-wasm32-wasi@2.1.1':
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
       '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
-  '@rspack-canary/binding-win32-arm64-msvc@2.1.0-canary-d00c9279-20260622184513':
+  '@rspack/binding-win32-arm64-msvc@2.0.8':
     optional: true
 
-  '@rspack-canary/binding-win32-ia32-msvc@2.1.0-canary-d00c9279-20260622184513':
+  '@rspack/binding-win32-arm64-msvc@2.1.1':
     optional: true
 
-  '@rspack-canary/binding-win32-x64-msvc@2.1.0-canary-d00c9279-20260622184513':
+  '@rspack/binding-win32-ia32-msvc@2.0.8':
     optional: true
 
-  '@rspack-canary/binding@2.1.0-canary-d00c9279-20260622184513':
+  '@rspack/binding-win32-ia32-msvc@2.1.1':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.0.8':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.1.1':
+    optional: true
+
+  '@rspack/binding@2.0.8':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': '@rspack-canary/binding-darwin-arm64@2.1.0-canary-d00c9279-20260622184513'
-      '@rspack/binding-darwin-x64': '@rspack-canary/binding-darwin-x64@2.1.0-canary-d00c9279-20260622184513'
-      '@rspack/binding-linux-arm64-gnu': '@rspack-canary/binding-linux-arm64-gnu@2.1.0-canary-d00c9279-20260622184513'
-      '@rspack/binding-linux-arm64-musl': '@rspack-canary/binding-linux-arm64-musl@2.1.0-canary-d00c9279-20260622184513'
-      '@rspack/binding-linux-x64-gnu': '@rspack-canary/binding-linux-x64-gnu@2.1.0-canary-d00c9279-20260622184513'
-      '@rspack/binding-linux-x64-musl': '@rspack-canary/binding-linux-x64-musl@2.1.0-canary-d00c9279-20260622184513'
-      '@rspack/binding-wasm32-wasi': '@rspack-canary/binding-wasm32-wasi@2.1.0-canary-d00c9279-20260622184513'
-      '@rspack/binding-win32-arm64-msvc': '@rspack-canary/binding-win32-arm64-msvc@2.1.0-canary-d00c9279-20260622184513'
-      '@rspack/binding-win32-ia32-msvc': '@rspack-canary/binding-win32-ia32-msvc@2.1.0-canary-d00c9279-20260622184513'
-      '@rspack/binding-win32-x64-msvc': '@rspack-canary/binding-win32-x64-msvc@2.1.0-canary-d00c9279-20260622184513'
+      '@rspack/binding-darwin-arm64': 2.0.8
+      '@rspack/binding-darwin-x64': 2.0.8
+      '@rspack/binding-linux-arm64-gnu': 2.0.8
+      '@rspack/binding-linux-arm64-musl': 2.0.8
+      '@rspack/binding-linux-x64-gnu': 2.0.8
+      '@rspack/binding-linux-x64-musl': 2.0.8
+      '@rspack/binding-wasm32-wasi': 2.0.8
+      '@rspack/binding-win32-arm64-msvc': 2.0.8
+      '@rspack/binding-win32-ia32-msvc': 2.0.8
+      '@rspack/binding-win32-x64-msvc': 2.0.8
 
-  '@rspack-canary/cli@2.1.0-canary-d00c9279-20260622184513(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))':
-    dependencies:
-      '@rspack/core': '@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23)'
+  '@rspack/binding@2.1.1':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.1.1
+      '@rspack/binding-darwin-x64': 2.1.1
+      '@rspack/binding-linux-arm64-gnu': 2.1.1
+      '@rspack/binding-linux-arm64-musl': 2.1.1
+      '@rspack/binding-linux-riscv64-gnu': 2.1.1
+      '@rspack/binding-linux-riscv64-musl': 2.1.1
+      '@rspack/binding-linux-x64-gnu': 2.1.1
+      '@rspack/binding-linux-x64-musl': 2.1.1
+      '@rspack/binding-wasm32-wasi': 2.1.1
+      '@rspack/binding-win32-arm64-msvc': 2.1.1
+      '@rspack/binding-win32-ia32-msvc': 2.1.1
+      '@rspack/binding-win32-x64-msvc': 2.1.1
 
-  '@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23)':
+  '@rspack/cli@2.1.1(@rspack/core@2.1.1(@swc/helpers@0.5.23))':
     dependencies:
-      '@rspack/binding': '@rspack-canary/binding@2.1.0-canary-d00c9279-20260622184513'
+      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
+
+  '@rspack/core@2.0.8(@swc/helpers@0.5.23)':
+    dependencies:
+      '@rspack/binding': 2.0.8
+    optionalDependencies:
+      '@swc/helpers': 0.5.23
+
+  '@rspack/core@2.1.1(@swc/helpers@0.5.23)':
+    dependencies:
+      '@rspack/binding': 2.1.1
     optionalDependencies:
       '@swc/helpers': 0.5.23
 
@@ -5328,7 +5503,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-loader@7.1.4(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0):
+  css-loader@7.1.4(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.3)
       postcss: 8.5.3
@@ -5339,7 +5514,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.1
     optionalDependencies:
-      '@rspack/core': '@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23)'
+      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
       webpack: 5.98.0(webpack-cli@5.1.4)
 
   css-select@4.3.0:
@@ -5937,12 +6112,12 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.39.0
 
-  html-webpack-externals-plugin@3.8.0(html-webpack-plugin@5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)):
+  html-webpack-externals-plugin@3.8.0(html-webpack-plugin@5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)):
     dependencies:
       ajv: 6.12.6
       copy-webpack-plugin: 4.6.0
       html-webpack-include-assets-plugin: 1.0.10
-      html-webpack-plugin: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+      html-webpack-plugin: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
 
   html-webpack-include-assets-plugin@1.0.10:
     dependencies:
@@ -5950,7 +6125,7 @@ snapshots:
       minimatch: 3.1.2
       slash: 2.0.0
 
-  html-webpack-plugin@5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0):
+  html-webpack-plugin@5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -5958,7 +6133,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.1
     optionalDependencies:
-      '@rspack/core': '@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23)'
+      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
       webpack: 5.98.0(webpack-cli@5.1.4)
 
   htmlparser2@6.1.0:
@@ -7088,11 +7263,11 @@ snapshots:
       sass-embedded-win32-arm64: 1.100.0
       sass-embedded-win32-x64: 1.100.0
 
-  sass-loader@16.0.8(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.98.0):
+  sass-loader@16.0.8(@rspack/core@2.1.1(@swc/helpers@0.5.23))(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.98.0):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
-      '@rspack/core': '@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23)'
+      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
       sass: 1.100.0
       sass-embedded: 1.100.0
       webpack: 5.98.0(webpack-cli@5.1.4)
@@ -7129,10 +7304,10 @@ snapshots:
       ajv-formats: 2.1.1(ajv@8.17.1)
       ajv-keywords: 5.1.0(ajv@8.17.1)
 
-  script-ext-html-webpack-plugin@2.1.5(html-webpack-plugin@5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0))(webpack@5.98.0):
+  script-ext-html-webpack-plugin@2.1.5(html-webpack-plugin@5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0))(webpack@5.98.0):
     dependencies:
       debug: 4.4.3
-      html-webpack-plugin: 5.6.7(@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513(@swc/helpers@0.5.23))(webpack@5.98.0)
+      html-webpack-plugin: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
       webpack: 5.98.0(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,25 +5,6 @@ allowBuilds:
   core-js: false
   puppeteer: false
 
-minimumReleaseAgeExclude:
-  - '@rspack-canary/binding-darwin-arm64@2.1.0-canary-d00c9279-20260622184513'
-  - '@rspack-canary/binding-darwin-x64@2.1.0-canary-d00c9279-20260622184513'
-  - '@rspack-canary/binding-linux-arm64-gnu@2.1.0-canary-d00c9279-20260622184513'
-  - '@rspack-canary/binding-linux-arm64-musl@2.1.0-canary-d00c9279-20260622184513'
-  - '@rspack-canary/binding-linux-x64-gnu@2.1.0-canary-d00c9279-20260622184513'
-  - '@rspack-canary/binding-linux-x64-musl@2.1.0-canary-d00c9279-20260622184513'
-  - '@rspack-canary/binding-wasm32-wasi@2.1.0-canary-d00c9279-20260622184513'
-  - '@rspack-canary/binding-win32-arm64-msvc@2.1.0-canary-d00c9279-20260622184513'
-  - '@rspack-canary/binding-win32-ia32-msvc@2.1.0-canary-d00c9279-20260622184513'
-  - '@rspack-canary/binding-win32-x64-msvc@2.1.0-canary-d00c9279-20260622184513'
-  - '@rspack-canary/binding@2.1.0-canary-d00c9279-20260622184513'
-  - '@rspack-canary/cli@2.1.0-canary-d00c9279-20260622184513'
-  - '@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513'
-
-overrides:
-  "@rspack/cli": "npm:@rspack-canary/cli@2.1.0-canary-d00c9279-20260622184513"
-  "@rspack/core": "npm:@rspack-canary/core@2.1.0-canary-d00c9279-20260622184513"
-
 peerDependencyRules:
   allowAny:
     - "@rspack/*"


### PR DESCRIPTION
## Summary

- update `@rspack/core` and `@rspack/cli` to `2.1.1`
- remove the temporary canary override from `pnpm-workspace.yaml`
- update the HTML plugin test to verify `output.module: true` behavior directly