### PR TITLE
chore: upgrade rspack canary

### DIFF
--- a/css-extract/cases/prefetch-preload/expected/main.js
+++ b/css-extract/cases/prefetch-preload/expected/main.js
@@ -286,7 +286,7 @@ __webpack_require__.p = scriptUrl;
 // webpack/runtime/css loading
 (() => {
 if (typeof document === "undefined") return;
-var createStylesheet = function (
+var extractCssCreateStylesheet = function (
 	chunkId, fullhref, oldTag, resolve, reject, fetchPriority
 ) {
 	var linkTag = document.createElement("link");
@@ -326,7 +326,7 @@ linkTag.href = fullhref;
           }
 	return linkTag;
 }
-var findStylesheet = function (href, fullhref) {
+var extractCssFindStylesheet = function (href, fullhref) {
 	var existingLinkTags = document.getElementsByTagName("link");
 	for (var i = 0; i < existingLinkTags.length; i++) {
 		var tag = existingLinkTags[i];
@@ -345,12 +345,12 @@ var findStylesheet = function (href, fullhref) {
 	}
 }
 
-var loadStylesheet = function (chunkId, fetchPriority) {
+var extractCssLoadStylesheet = function (chunkId, fetchPriority) {
 	return new Promise(function (resolve, reject) {
 		var href = __webpack_require__.miniCssF(chunkId);
 		var fullhref = __webpack_require__.p + href;
-		if (findStylesheet(href, fullhref)) return resolve();
-		createStylesheet(chunkId, fullhref, null, resolve, reject, fetchPriority);
+		if (extractCssFindStylesheet(href, fullhref)) return resolve();
+		extractCssCreateStylesheet(chunkId, fullhref, null, resolve, reject, fetchPriority);
 	})
 }
 
@@ -372,7 +372,7 @@ __webpack_require__.f.miniCss = function (chunkId, promises, fetchPriority) {
 	if (installedCssChunks[chunkId]) promises.push(installedCssChunks[chunkId])
 	else if (installedCssChunks[chunkId] !== 0 && cssChunks[chunkId])
 		promises.push(
-			installedCssChunks[chunkId] = loadStylesheet(chunkId, fetchPriority).then(
+			installedCssChunks[chunkId] = extractCssLoadStylesheet(chunkId, fetchPriority).then(
 				function () {
 					installedCssChunks[chunkId] = 0;
 				},
@@ -424,12 +424,12 @@ link.href = __webpack_require__.p + __webpack_require__.miniCssF(chunkId);
       // object to store loaded and loading chunks
       // undefined = chunk not loaded, null = chunk preloaded/prefetched
       // [resolve, reject, Promise] = chunk loading, 0 = chunk loaded
-      var installedChunks = {"main": 0,};
+      var jsonpInstalledChunks = {"main": 0,};
       
         __webpack_require__.f.j = function (chunkId, promises) {
           // JSONP chunk loading for javascript
-var installedChunkData = __webpack_require__.o(installedChunks, chunkId)
-	? installedChunks[chunkId]
+var installedChunkData = __webpack_require__.o(jsonpInstalledChunks, chunkId)
+	? jsonpInstalledChunks[chunkId]
 	: undefined;
 if (installedChunkData !== 0) {
 	// 0 means "already installed".
@@ -440,7 +440,7 @@ if (installedChunkData !== 0) {
 	} else {
 		if (true) {
 			// setup Promise in chunk cache
-			var promise = new Promise((resolve, reject) => (installedChunkData = installedChunks[chunkId] = [resolve, reject]));
+			var promise = new Promise((resolve, reject) => (installedChunkData = jsonpInstalledChunks[chunkId] = [resolve, reject]));
 			promises.push((installedChunkData[2] = promise));
 
 			// start chunk loading
@@ -448,9 +448,9 @@ if (installedChunkData !== 0) {
 			// create error before stack unwound to get useful stacktrace later
 			var error = new Error();
 			var loadingEnded = function (event) {
-				if (__webpack_require__.o(installedChunks, chunkId)) {
-					installedChunkData = installedChunks[chunkId];
-					if (installedChunkData !== 0) installedChunks[chunkId] = undefined;
+				if (__webpack_require__.o(jsonpInstalledChunks, chunkId)) {
+					installedChunkData = jsonpInstalledChunks[chunkId];
+					if (installedChunkData !== 0) jsonpInstalledChunks[chunkId] = undefined;
 					if (installedChunkData) {
 						var errorType =
 							event && (event.type === 'load' ? 'missing' : event.type);
@@ -477,8 +477,8 @@ if (installedChunkData !== 0) {
 
         }
         __webpack_require__.F.j = (chunkId) => {
-  if ((!__webpack_require__.o(installedChunks, chunkId) || installedChunks[chunkId] === undefined) && true) {
-    installedChunks[chunkId] = null;
+  if ((!__webpack_require__.o(jsonpInstalledChunks, chunkId) || jsonpInstalledChunks[chunkId] === undefined) && true) {
+    jsonpInstalledChunks[chunkId] = null;
     var link = document.createElement('link');
 
 if (__webpack_require__.nc) {
@@ -492,8 +492,8 @@ link.href = __webpack_require__.p + __webpack_require__.u(chunkId);
   }
 };
 __webpack_require__.H.j = (chunkId) => {
-  if ((!__webpack_require__.o(installedChunks, chunkId) || installedChunks[chunkId] === undefined) && true) {
-    installedChunks[chunkId] = null;
+  if ((!__webpack_require__.o(jsonpInstalledChunks, chunkId) || jsonpInstalledChunks[chunkId] === undefined) && true) {
+    jsonpInstalledChunks[chunkId] = null;
     var link = document.createElement('link');
 
 if (__webpack_require__.nc) {
@@ -509,14 +509,14 @@ link.href = __webpack_require__.p + __webpack_require__.u(chunkId);
     document.head.appendChild(link);
   }
 };
-__webpack_require__.O.j = (chunkId) => (installedChunks[chunkId] === 0);
+__webpack_require__.O.j = (chunkId) => (jsonpInstalledChunks[chunkId] === 0);
 // install a JSONP callback for chunk loading
 var __rspack_jsonp = (parentChunkLoadingFunction, data) => {
 	var [chunkIds, moreModules, runtime] = data;
 	// add "moreModules" to the modules object,
 	// then flag all "chunkIds" as loaded and fire callback
 	var moduleId, chunkId, i = 0;
-	if (chunkIds.some((id) => (installedChunks[id] !== 0))) {
+	if (chunkIds.some((id) => (jsonpInstalledChunks[id] !== 0))) {
 		for (moduleId in moreModules) {
 			if (__webpack_require__.o(moreModules, moduleId)) {
 				__webpack_require__.m[moduleId] = moreModules[moduleId];
@@ -528,21 +528,21 @@ var __rspack_jsonp = (parentChunkLoadingFunction, data) => {
 	for (; i < chunkIds.length; i++) {
 		chunkId = chunkIds[i];
 		if (
-			__webpack_require__.o(installedChunks, chunkId) &&
-			installedChunks[chunkId]
+			__webpack_require__.o(jsonpInstalledChunks, chunkId) &&
+			jsonpInstalledChunks[chunkId]
 		) {
-			installedChunks[chunkId][0]();
+			jsonpInstalledChunks[chunkId][0]();
 		}
-		installedChunks[chunkId] = 0;
+		jsonpInstalledChunks[chunkId] = 0;
 	}
 	
 	return __webpack_require__.O(result);
 	
 };
 
-var chunkLoadingGlobal = self["rspackChunk"] = self["rspackChunk"] || [];
-chunkLoadingGlobal.forEach(__rspack_jsonp.bind(null, 0));
-chunkLoadingGlobal.push = __rspack_jsonp.bind(null, chunkLoadingGlobal.push.bind(chunkLoadingGlobal));
+var jsonpChunkLoadingGlobal = self["rspackChunk"] = self["rspackChunk"] || [];
+jsonpChunkLoadingGlobal.forEach(__rspack_jsonp.bind(null, 0));
+jsonpChunkLoadingGlobal.push = __rspack_jsonp.bind(null, jsonpChunkLoadingGlobal.push.bind(jsonpChunkLoadingGlobal));
 
 })();
 // webpack/runtime/chunk_prefetch_startup
@@ -553,21 +553,23 @@ __webpack_require__.O(0, ["main"], () => {
 })();
 // webpack/runtime/chunk_prefetch_trigger
 (() => {
-var chunkToChildrenMap = {"b":["b1","b3"]};
+var chunkPrefetchChunkToChildrenMap = {"b":["b1","b3"]};
 __webpack_require__.f.prefetch = (chunkId, promises) => {
   Promise.all(promises).then(() => {
-    var chunks = chunkToChildrenMap[chunkId];
+    var chunks = chunkPrefetchChunkToChildrenMap[chunkId];
     Array.isArray(chunks) && chunks.map(__webpack_require__.E);
   });
 };
+
 })();
 // webpack/runtime/chunk_preload_trigger
 (() => {
-var chunkToChildrenMap = {"b":["b2"],"c":["c1","c2"]};
+var chunkPreloadChunkToChildrenMap = {"b":["b2"],"c":["c1","c2"]};
 __webpack_require__.f.preload =  (chunkId) => {
-  var chunks = chunkToChildrenMap[chunkId];
+  var chunks = chunkPreloadChunkToChildrenMap[chunkId];
   Array.isArray(chunks) && chunks.map(__webpack_require__.G);
 };
+
 })();
 // module factories are used so entry inlining is disabled
 // startup

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@rspack/cli': npm:@rspack-canary/cli@2.1.4-canary-77f56582-20260708031112
+  '@rspack/core': npm:@rspack-canary/core@2.1.4-canary-77f56582-20260708031112
+
 importers:
 
   .:
@@ -12,11 +16,11 @@ importers:
         specifier: ^0.6.1
         version: 0.6.1
       '@rspack/cli':
-        specifier: 2.1.1
-        version: 2.1.1(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        specifier: npm:@rspack-canary/cli@2.1.4-canary-77f56582-20260708031112
+        version: '@rspack-canary/cli@2.1.4-canary-77f56582-20260708031112(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))'
       '@rspack/core':
-        specifier: 2.1.1
-        version: 2.1.1(@swc/helpers@0.5.23)
+        specifier: npm:@rspack-canary/core@2.1.4-canary-77f56582-20260708031112
+        version: '@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23)'
       '@rstest/core':
         specifier: ^0.10.4
         version: 0.10.4(jsdom@25.0.1)
@@ -46,7 +50,7 @@ importers:
         version: 7.0.6
       css-loader:
         specifier: ^7.1.4
-        version: 7.1.4(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 7.1.4(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       del:
         specifier: ^6.1.1
         version: 6.1.1
@@ -73,7 +77,7 @@ importers:
         version: 2.1.2(webpack@5.98.0)
       html-webpack-plugin:
         specifier: 5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1
@@ -94,7 +98,7 @@ importers:
         version: 1.100.0
       sass-loader:
         specifier: ^16.0.8
-        version: 16.0.8(@rspack/core@2.1.1(@swc/helpers@0.5.23))(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.98.0)
+        version: 16.0.8(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.98.0)
       tmp:
         specifier: ^0.2.5
         version: 0.2.5
@@ -127,7 +131,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -148,7 +152,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -163,7 +167,7 @@ importers:
     devDependencies:
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -178,7 +182,7 @@ importers:
     devDependencies:
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -196,7 +200,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -211,7 +215,7 @@ importers:
     devDependencies:
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -226,7 +230,7 @@ importers:
     devDependencies:
       css-loader:
         specifier: ^7.1.4
-        version: 7.1.4(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 7.1.4(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       css-select:
         specifier: ^5.2.2
         version: 5.2.2
@@ -235,7 +239,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       htmlparser2:
         specifier: ^8.0.2
         version: 8.0.2
@@ -262,10 +266,10 @@ importers:
         version: 26.6.2
       html-webpack-externals-plugin:
         specifier: ^3.8.0
-        version: 3.8.0(html-webpack-plugin@5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0))
+        version: 3.8.0(html-webpack-plugin@5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0))
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       htmlparser2:
         specifier: ^8.0.2
         version: 8.0.2
@@ -289,7 +293,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       htmlparser2:
         specifier: ^8.0.2
         version: 8.0.2
@@ -313,7 +317,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       htmlparser2:
         specifier: ^8.0.2
         version: 8.0.2
@@ -337,7 +341,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       htmlparser2:
         specifier: ^8.0.2
         version: 8.0.2
@@ -355,13 +359,13 @@ importers:
     devDependencies:
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
       script-ext-html-webpack-plugin:
         specifier: ^2.1.5
-        version: 2.1.5(html-webpack-plugin@5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0))(webpack@5.98.0)
+        version: 2.1.5(html-webpack-plugin@5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0))(webpack@5.98.0)
       webpack:
         specifier: 5.98.0
         version: 5.98.0(webpack-cli@5.1.4)
@@ -388,13 +392,13 @@ importers:
     devDependencies:
       css-loader:
         specifier: ^7.1.4
-        version: 7.1.4(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 7.1.4(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       expect:
         specifier: ^26.6.2
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       mini-css-extract-plugin:
         specifier: ^1.6.2
         version: 1.6.2(webpack@5.98.0)
@@ -415,7 +419,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -430,7 +434,7 @@ importers:
     devDependencies:
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -448,7 +452,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -466,7 +470,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -484,7 +488,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -502,7 +506,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -517,7 +521,7 @@ importers:
     devDependencies:
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -532,10 +536,10 @@ importers:
     devDependencies:
       css-loader:
         specifier: ^7.1.4
-        version: 7.1.4(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 7.1.4(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       mini-css-extract-plugin:
         specifier: ^1.6.2
         version: 1.6.2(webpack@5.98.0)
@@ -556,7 +560,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -574,7 +578,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -592,7 +596,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -610,7 +614,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -628,7 +632,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -646,7 +650,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -664,7 +668,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -679,7 +683,7 @@ importers:
     devDependencies:
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -700,7 +704,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -718,7 +722,7 @@ importers:
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -736,13 +740,13 @@ importers:
     devDependencies:
       css-loader:
         specifier: ^7.1.4
-        version: 7.1.4(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 7.1.4(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       expect:
         specifier: ^26.6.2
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       mini-css-extract-plugin:
         specifier: ^1.6.2
         version: 1.6.2(webpack@5.98.0)
@@ -766,7 +770,7 @@ importers:
     devDependencies:
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -781,7 +785,7 @@ importers:
     devDependencies:
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       nyc:
         specifier: '*'
         version: 18.0.0
@@ -796,13 +800,13 @@ importers:
     devDependencies:
       css-loader:
         specifier: ^7.1.4
-        version: 7.1.4(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 7.1.4(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       expect:
         specifier: ^26.6.2
         version: 26.6.2
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+        version: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       mini-css-extract-plugin:
         specifier: ^1.6.2
         version: 1.6.2(webpack@5.98.0)
@@ -923,20 +927,11 @@ packages:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
 
-  '@emnapi/core@1.10.0':
-    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
-
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
-  '@emnapi/runtime@1.10.0':
-    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
-
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
-
-  '@emnapi/wasi-threads@1.2.1':
-    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
@@ -1137,14 +1132,8 @@ packages:
     peerDependencies:
       tslib: '2'
 
-  '@napi-rs/wasm-runtime@1.1.4':
-    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
-
-  '@napi-rs/wasm-runtime@1.1.5':
-    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
@@ -1324,132 +1313,76 @@ packages:
   '@rslint/native@0.6.1':
     resolution: {integrity: sha512-WR/tITtBCjxkBhpDRip4h6n+gxMMqqijFKmDjuc3O/ScWMrX+KbeKcnS0u1Y8e0YfoAmk7dHR9HIT+IRHod1IQ==}
 
-  '@rspack/binding-darwin-arm64@2.0.8':
-    resolution: {integrity: sha512-vCgbgH7B7qom+uID+RCZsTCOYFb9wC4/4+1U6rMfytrXGVJ72eNQs2tbdjOl0lb18CT3N/n+VkWynUiLk84GwA==}
+  '@rspack-canary/binding-darwin-arm64@2.1.4-canary-77f56582-20260708031112':
+    resolution: {integrity: sha512-inhvxkoYoCqdziblHJ6KOOXHyWIu09HNHY5gNaGLIr5zIu14dRBQ32uetSZiVuhkxFCokMmlG1r5t/sm3NEUjA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-arm64@2.1.1':
-    resolution: {integrity: sha512-6K8jA3pZphBwLt5DU78wl0IzY1myHrqNSvFVCd9CHa+szlOwv2iMQpZdYdpupIBxwiZ39rrDyQKtoZw7lsAG8w==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-x64@2.0.8':
-    resolution: {integrity: sha512-satPm2PD4B7jDTVlVAdvMVdUszwLvWUEnUDzLb77mvVkezKNDZmuhb+e8s+FfKs8hJpNbZ9VAejuA2rr8o985w==}
+  '@rspack-canary/binding-darwin-x64@2.1.4-canary-77f56582-20260708031112':
+    resolution: {integrity: sha512-hjzHwc4uZUI3Y5NDtR3Tbtcj7Ijr4m2TmASp9qjoFXosQOBepYZGqPcXlExlMUMFK3AXXauN6CQ4d/SEXxIV/A==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@2.1.1':
-    resolution: {integrity: sha512-RdqtEfIbSe5ucLNVvMac1k88UwmL4Gil8uXqlEFcSZ3VC2jTOkecadd+B0RYqJ+PirSInrRmKm1cr0740zppOA==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rspack/binding-linux-arm64-gnu@2.0.8':
-    resolution: {integrity: sha512-pSI+npPQE/uDtiboqvcOIRJbEV2+B+H1xffmko/gw50la92oTUW60kVULFwsb6L0+GVCzIcwX3yq60GtYIn+Ug==}
+  '@rspack-canary/binding-linux-arm64-gnu@2.1.4-canary-77f56582-20260708031112':
+    resolution: {integrity: sha512-6kRtTB7RqLh1voOORdGDjBV7IqnyPJAJAcNLVjCThCVEKh6UtMMH2+xlDQ9CVIPZtQQ7r2FcM32DiKaBIi/Grg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-arm64-gnu@2.1.1':
-    resolution: {integrity: sha512-ROKtqXoLpbZO1vYEcNxQg6COvRhdlJcoib1Z4pzG1nIyctEAUuFmnD7pIvJiVe6M7YuJNXW+1p0BhpptT2XEUQ==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rspack/binding-linux-arm64-musl@2.0.8':
-    resolution: {integrity: sha512-igjJ43yxWQ72GZqjDDZSSHax9/Vg+6rLMmOvFglTJUkQpB4Tyvu/YjW+WRjYj2xRw6blOjLxUSJWASvuSqqlvg==}
+  '@rspack-canary/binding-linux-arm64-musl@2.1.4-canary-77f56582-20260708031112':
+    resolution: {integrity: sha512-kUY9nR8yrVzXgdGng7pYxTA2eqpzwWdRQdNpgM7EpDNN9Vo04d4Hql4X3zfOmZAkcDrGQn7r5JvqNhxtwO/i5g==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-arm64-musl@2.1.1':
-    resolution: {integrity: sha512-QdQpG9dK0GfPASjBd/8rUwDNW0ShfFfYJfcoGLNTM6A8EqmgvWwklXDiCVF5dXALbZIksAuRznIKnLDsUoXi9Q==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@rspack/binding-linux-riscv64-gnu@2.1.1':
-    resolution: {integrity: sha512-LGdYCAvblZp2qtHk9UseYftIRyaBzSWqEzd1toaS08sYESXERm+YBbrYKKiyq1yXiU1L7BkhMUxiWc3GCYmKcA==}
+  '@rspack-canary/binding-linux-riscv64-gnu@2.1.4-canary-77f56582-20260708031112':
+    resolution: {integrity: sha512-6DNMiKaViKFfI5HI6UyNrb0S9LQwC0WPGigNkArDx+1yvyCbGe4LMpOpdbNfcu2lY9S6UpnweuqokfryNSdCzQ==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-riscv64-musl@2.1.1':
-    resolution: {integrity: sha512-87phiiPGFT1p4gy3Oz6YdNijCPXdjJy43LFdE8AFiZsV4ChFXQPqnVCF2aMRLybYa51A+9wGYlTvxt09yUQUww==}
+  '@rspack-canary/binding-linux-riscv64-musl@2.1.4-canary-77f56582-20260708031112':
+    resolution: {integrity: sha512-UOHvqwQdzJRaDPcQZeeyq2weJ/aXu95rP/khA0fAArj5uyh0mD4bEoXBnaqlrRGQQnQ8VTurWS3Xp+ZJnMGKBA==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-x64-gnu@2.0.8':
-    resolution: {integrity: sha512-zrkoEOnqj1hOEBO5T2I/2Ts2HSJsYFh1qXwMpK4dMJFGGNWDfNeUa6/LF5uq3VINF3JUl7RL47AgrucoSZJXPA==}
+  '@rspack-canary/binding-linux-x64-gnu@2.1.4-canary-77f56582-20260708031112':
+    resolution: {integrity: sha512-54hisBDa7fg3FluKLRWjds+WXrSmxtZgi1mpPlWNMwMWSYbkoUIOpRjHXfMdH/FLKsnKCVWd4zbWBEqn+LoX/g==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-x64-gnu@2.1.1':
-    resolution: {integrity: sha512-om0/PvZzxISsnyz3hdmI3xBi3Qsn6faRGrfp6WJpGHa5JYYaRVWz1MJ9fe+/cQE9ON9r32HpMOeuataCLv+Owg==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rspack/binding-linux-x64-musl@2.0.8':
-    resolution: {integrity: sha512-6CtDaGZjNDvJd9TBp7a9zABbrPORO21W96+3ZcGBn0YNUPUk4ARxIxrTTpeJ/1F41QDM8AYIkGDdqEYMqTYBsA==}
+  '@rspack-canary/binding-linux-x64-musl@2.1.4-canary-77f56582-20260708031112':
+    resolution: {integrity: sha512-P47mxg/E35AF7xyRDLHKFJOMo8zXZvx6HA8lFyFiIXsdEw/Dovvy9IxsPyNHDHMHa+bLbwVT4OIhVxfC0DgzOw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-x64-musl@2.1.1':
-    resolution: {integrity: sha512-YgAyTOM5ZWvWT0Exwcg7QkGUv9PsHT4yIsEyJbH+a99uAKliGMwkHIOP/aJgrCF8G+lTfigY2wyl9cWo4TA4aw==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@rspack/binding-wasm32-wasi@2.0.8':
-    resolution: {integrity: sha512-Yf4SiqTUroT5Ju+te0YAY2xxKOb35tECsO21v7hYyGa705wrgoAK/MmF7enOvs9GR1iZIqgiLD/wxsIxl8GjJw==}
+  '@rspack-canary/binding-wasm32-wasi@2.1.4-canary-77f56582-20260708031112':
+    resolution: {integrity: sha512-vGG1C5vxhF4YzZTlN7Q4lgnacbXX+jmZ01oHUbShXwL7sNIqGT4qKkQXLnZOsy5QOBSxTj+6auWELyjIbIcvsg==}
     cpu: [wasm32]
 
-  '@rspack/binding-wasm32-wasi@2.1.1':
-    resolution: {integrity: sha512-OicgaB3Dcd+KXsH/I3DkJG7XQyREJScg/jLkCtycFn9BhT0IVJvgi37F8QNJKl8Bp9YZIGehsqK9HpQWav6SLw==}
-    cpu: [wasm32]
-
-  '@rspack/binding-win32-arm64-msvc@2.0.8':
-    resolution: {integrity: sha512-8NCuiQsAhXrwRBy57QZoypqrws/zLBkaQVGiB8hksr6v++8hNigNjqpQARLbd0iyMuHsQQ++8+auGk6xlDXmzw==}
+  '@rspack-canary/binding-win32-arm64-msvc@2.1.4-canary-77f56582-20260708031112':
+    resolution: {integrity: sha512-X7QJK7ji9bSZfAlSC2X9iWAWwgd86My3YjozL2rz4gJp/sRbsY3InEP7CUj/GkshnC9gzhF/7uh7cdwWN4Bipw==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-arm64-msvc@2.1.1':
-    resolution: {integrity: sha512-fwL4P3SsC0r/vVGgnmexnc4vkvf+9vWMcGw5fdlPBJNR/zWlZRSXR5V6eXcHrpYVLhBsLYvZYE3NZa9paIUGxw==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rspack/binding-win32-ia32-msvc@2.0.8':
-    resolution: {integrity: sha512-bxiekytbX7V9KFAra+HkwtNWC6pYfHEBBZFpiT0xUs3mCFOmAAFVBsBSQsoCP9AdCEXoMAvNdnrHNw3iov4OZw==}
+  '@rspack-canary/binding-win32-ia32-msvc@2.1.4-canary-77f56582-20260708031112':
+    resolution: {integrity: sha512-BxawS3LcHbuR4VM8wJMVoEF/FvkeqweCTpEKBUn49nIf58BvveK8BW3X+y0QPtNg4GCwCIbcyHfH1IMA1Ad0SA==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@2.1.1':
-    resolution: {integrity: sha512-j3BISXbjPyI57HeHxW9Jx+UP7RebNQ4t62uCbRP29caf9aghYJP+ZA5nJ2X7pol7N5Je2/V6WNahuNd0zQFDOA==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rspack/binding-win32-x64-msvc@2.0.8':
-    resolution: {integrity: sha512-7zPs8YCe/ZVJTwd+5lpB0CP0tkn2pONf/T1ycmVY76u21Nrwt8mXQGc/2yH2eWP4B7fikYBr3hGr7mpR2fajqQ==}
+  '@rspack-canary/binding-win32-x64-msvc@2.1.4-canary-77f56582-20260708031112':
+    resolution: {integrity: sha512-EeTRsDM7JZxVjaGQsyI8JTeiyy5bQJnRxcDoa0zVKjybsBQXhm7Uk9jvlN9FBIT+mM/aOImM3s65BymwggpFTw==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@2.1.1':
-    resolution: {integrity: sha512-aPNNFuZT5iBM8+S9J4P5ywJbf3tUvZN3Ppe6mXJ8/jTVDUDhe0YVj3AgD/AuxnUvl+yHrLfQkN1nNwUfIcomfA==}
-    cpu: [x64]
-    os: [win32]
+  '@rspack-canary/binding@2.1.4-canary-77f56582-20260708031112':
+    resolution: {integrity: sha512-l68vUFQUEMU1DWpcQjHPWyefLApJUuRhnirC/z26qcUK1MHbAzjkYZ25MGjYLuBU52Mb/fKqQJ/uu9MtapnsLw==}
 
-  '@rspack/binding@2.0.8':
-    resolution: {integrity: sha512-3uZ+y8aQxq33ty2srMxg2Nu0XuBI6vVrG50rkDaXqwWqOohfgGUSfFuQK7EnSUNy4aFUQlCG6NHialQHJov0wg==}
-
-  '@rspack/binding@2.1.1':
-    resolution: {integrity: sha512-6062hZP33fn1w51ClpQnum19GGXl/3eS754xrRYbQ7wwBNZk94HVwfSyiqcNCtY/pB1lsFjnaTKiW/Q+jv0axQ==}
-
-  '@rspack/cli@2.1.1':
-    resolution: {integrity: sha512-zsJFurwCDesy0dud7cejObagbbXsvKcQ6j485nmnytBsXV17Uf6XfedQMxnOXBZeGIel+I7Jl/Jp3Sn08TsZuw==}
+  '@rspack-canary/cli@2.1.4-canary-77f56582-20260708031112':
+    resolution: {integrity: sha512-bQcJA9hjKToTzoOUtX2OGGapYTeH4ZFQlZe+t/bqUQfm68/eT/GBtIJEeUytfhrozlM3ON8nR2MA6ZMFt8T7bw==}
     hasBin: true
     peerDependencies:
       '@rspack/core': ^2.0.0-0
@@ -1458,20 +1391,8 @@ packages:
       '@rspack/dev-server':
         optional: true
 
-  '@rspack/core@2.0.8':
-    resolution: {integrity: sha512-+NLGJf8gZxihDmMFzjlly3toc2SMjeDmuvz0/Cai9AMdV4F+Pqcnt2BA9V4e3SY2jmhJQtPwgyyLtR1RiJO77g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    peerDependencies:
-      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
-      '@swc/helpers': ^0.5.23
-    peerDependenciesMeta:
-      '@module-federation/runtime-tools':
-        optional: true
-      '@swc/helpers':
-        optional: true
-
-  '@rspack/core@2.1.1':
-    resolution: {integrity: sha512-Rgz6xZcD0rm7ejZhYNi13qvW2dSnIQQt/7D3xbYoT5hOU838JbkF0P3SAMFGKE+FyLZswnyRpxGfnYHZQqDmJA==}
+  '@rspack-canary/core@2.1.4-canary-77f56582-20260708031112':
+    resolution: {integrity: sha512-lAP+PPowf5Qb8mrojHktO8X/fb5Jn8rxShEB+Ku5sjs3dtXxyuk9sR1fB9sj7MlggVdDggC5DkchUnMlsFV+Lg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -1504,8 +1425,8 @@ packages:
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
-  '@tybys/wasm-util@0.10.2':
-    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -4398,29 +4319,13 @@ snapshots:
 
   '@discoveryjs/json-ext@0.5.7': {}
 
-  '@emnapi/core@1.10.0':
-    dependencies:
-      '@emnapi/wasi-threads': 1.2.1
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.10.0':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/runtime@1.11.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -4654,18 +4559,11 @@ snapshots:
       '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
       tslib: 2.8.1
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.2
-    optional: true
-
-  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
-      '@tybys/wasm-util': 0.10.2
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -4759,7 +4657,7 @@ snapshots:
 
   '@rsbuild/core@2.0.14':
     dependencies:
-      '@rspack/core': 2.0.8(@swc/helpers@0.5.23)
+      '@rspack/core': '@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23)'
       '@swc/helpers': 0.5.23
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -4813,121 +4711,68 @@ snapshots:
       '@rslint/native-win32-arm64-msvc': 0.6.1
       '@rslint/native-win32-x64-msvc': 0.6.1
 
-  '@rspack/binding-darwin-arm64@2.0.8':
+  '@rspack-canary/binding-darwin-arm64@2.1.4-canary-77f56582-20260708031112':
     optional: true
 
-  '@rspack/binding-darwin-arm64@2.1.1':
+  '@rspack-canary/binding-darwin-x64@2.1.4-canary-77f56582-20260708031112':
     optional: true
 
-  '@rspack/binding-darwin-x64@2.0.8':
+  '@rspack-canary/binding-linux-arm64-gnu@2.1.4-canary-77f56582-20260708031112':
     optional: true
 
-  '@rspack/binding-darwin-x64@2.1.1':
+  '@rspack-canary/binding-linux-arm64-musl@2.1.4-canary-77f56582-20260708031112':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@2.0.8':
+  '@rspack-canary/binding-linux-riscv64-gnu@2.1.4-canary-77f56582-20260708031112':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@2.1.1':
+  '@rspack-canary/binding-linux-riscv64-musl@2.1.4-canary-77f56582-20260708031112':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@2.0.8':
+  '@rspack-canary/binding-linux-x64-gnu@2.1.4-canary-77f56582-20260708031112':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@2.1.1':
+  '@rspack-canary/binding-linux-x64-musl@2.1.4-canary-77f56582-20260708031112':
     optional: true
 
-  '@rspack/binding-linux-riscv64-gnu@2.1.1':
-    optional: true
-
-  '@rspack/binding-linux-riscv64-musl@2.1.1':
-    optional: true
-
-  '@rspack/binding-linux-x64-gnu@2.0.8':
-    optional: true
-
-  '@rspack/binding-linux-x64-gnu@2.1.1':
-    optional: true
-
-  '@rspack/binding-linux-x64-musl@2.0.8':
-    optional: true
-
-  '@rspack/binding-linux-x64-musl@2.1.1':
-    optional: true
-
-  '@rspack/binding-wasm32-wasi@2.0.8':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-    optional: true
-
-  '@rspack/binding-wasm32-wasi@2.1.1':
+  '@rspack-canary/binding-wasm32-wasi@2.1.4-canary-77f56582-20260708031112':
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@2.0.8':
+  '@rspack-canary/binding-win32-arm64-msvc@2.1.4-canary-77f56582-20260708031112':
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@2.1.1':
+  '@rspack-canary/binding-win32-ia32-msvc@2.1.4-canary-77f56582-20260708031112':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@2.0.8':
+  '@rspack-canary/binding-win32-x64-msvc@2.1.4-canary-77f56582-20260708031112':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@2.1.1':
-    optional: true
-
-  '@rspack/binding-win32-x64-msvc@2.0.8':
-    optional: true
-
-  '@rspack/binding-win32-x64-msvc@2.1.1':
-    optional: true
-
-  '@rspack/binding@2.0.8':
+  '@rspack-canary/binding@2.1.4-canary-77f56582-20260708031112':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.0.8
-      '@rspack/binding-darwin-x64': 2.0.8
-      '@rspack/binding-linux-arm64-gnu': 2.0.8
-      '@rspack/binding-linux-arm64-musl': 2.0.8
-      '@rspack/binding-linux-x64-gnu': 2.0.8
-      '@rspack/binding-linux-x64-musl': 2.0.8
-      '@rspack/binding-wasm32-wasi': 2.0.8
-      '@rspack/binding-win32-arm64-msvc': 2.0.8
-      '@rspack/binding-win32-ia32-msvc': 2.0.8
-      '@rspack/binding-win32-x64-msvc': 2.0.8
+      '@rspack/binding-darwin-arm64': '@rspack-canary/binding-darwin-arm64@2.1.4-canary-77f56582-20260708031112'
+      '@rspack/binding-darwin-x64': '@rspack-canary/binding-darwin-x64@2.1.4-canary-77f56582-20260708031112'
+      '@rspack/binding-linux-arm64-gnu': '@rspack-canary/binding-linux-arm64-gnu@2.1.4-canary-77f56582-20260708031112'
+      '@rspack/binding-linux-arm64-musl': '@rspack-canary/binding-linux-arm64-musl@2.1.4-canary-77f56582-20260708031112'
+      '@rspack/binding-linux-riscv64-gnu': '@rspack-canary/binding-linux-riscv64-gnu@2.1.4-canary-77f56582-20260708031112'
+      '@rspack/binding-linux-riscv64-musl': '@rspack-canary/binding-linux-riscv64-musl@2.1.4-canary-77f56582-20260708031112'
+      '@rspack/binding-linux-x64-gnu': '@rspack-canary/binding-linux-x64-gnu@2.1.4-canary-77f56582-20260708031112'
+      '@rspack/binding-linux-x64-musl': '@rspack-canary/binding-linux-x64-musl@2.1.4-canary-77f56582-20260708031112'
+      '@rspack/binding-wasm32-wasi': '@rspack-canary/binding-wasm32-wasi@2.1.4-canary-77f56582-20260708031112'
+      '@rspack/binding-win32-arm64-msvc': '@rspack-canary/binding-win32-arm64-msvc@2.1.4-canary-77f56582-20260708031112'
+      '@rspack/binding-win32-ia32-msvc': '@rspack-canary/binding-win32-ia32-msvc@2.1.4-canary-77f56582-20260708031112'
+      '@rspack/binding-win32-x64-msvc': '@rspack-canary/binding-win32-x64-msvc@2.1.4-canary-77f56582-20260708031112'
 
-  '@rspack/binding@2.1.1':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.1.1
-      '@rspack/binding-darwin-x64': 2.1.1
-      '@rspack/binding-linux-arm64-gnu': 2.1.1
-      '@rspack/binding-linux-arm64-musl': 2.1.1
-      '@rspack/binding-linux-riscv64-gnu': 2.1.1
-      '@rspack/binding-linux-riscv64-musl': 2.1.1
-      '@rspack/binding-linux-x64-gnu': 2.1.1
-      '@rspack/binding-linux-x64-musl': 2.1.1
-      '@rspack/binding-wasm32-wasi': 2.1.1
-      '@rspack/binding-win32-arm64-msvc': 2.1.1
-      '@rspack/binding-win32-ia32-msvc': 2.1.1
-      '@rspack/binding-win32-x64-msvc': 2.1.1
-
-  '@rspack/cli@2.1.1(@rspack/core@2.1.1(@swc/helpers@0.5.23))':
+  '@rspack-canary/cli@2.1.4-canary-77f56582-20260708031112(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))':
     dependencies:
-      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
+      '@rspack/core': '@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23)'
 
-  '@rspack/core@2.0.8(@swc/helpers@0.5.23)':
+  '@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23)':
     dependencies:
-      '@rspack/binding': 2.0.8
-    optionalDependencies:
-      '@swc/helpers': 0.5.23
-
-  '@rspack/core@2.1.1(@swc/helpers@0.5.23)':
-    dependencies:
-      '@rspack/binding': 2.1.1
+      '@rspack/binding': '@rspack-canary/binding@2.1.4-canary-77f56582-20260708031112'
     optionalDependencies:
       '@swc/helpers': 0.5.23
 
@@ -4949,7 +4794,7 @@ snapshots:
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
-  '@tybys/wasm-util@0.10.2':
+  '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -5503,7 +5348,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-loader@7.1.4(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0):
+  css-loader@7.1.4(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.3)
       postcss: 8.5.3
@@ -5514,7 +5359,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.1
     optionalDependencies:
-      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
+      '@rspack/core': '@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23)'
       webpack: 5.98.0(webpack-cli@5.1.4)
 
   css-select@4.3.0:
@@ -6112,12 +5957,12 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.39.0
 
-  html-webpack-externals-plugin@3.8.0(html-webpack-plugin@5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)):
+  html-webpack-externals-plugin@3.8.0(html-webpack-plugin@5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)):
     dependencies:
       ajv: 6.12.6
       copy-webpack-plugin: 4.6.0
       html-webpack-include-assets-plugin: 1.0.10
-      html-webpack-plugin: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+      html-webpack-plugin: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
 
   html-webpack-include-assets-plugin@1.0.10:
     dependencies:
@@ -6125,7 +5970,7 @@ snapshots:
       minimatch: 3.1.2
       slash: 2.0.0
 
-  html-webpack-plugin@5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0):
+  html-webpack-plugin@5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -6133,7 +5978,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.1
     optionalDependencies:
-      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
+      '@rspack/core': '@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23)'
       webpack: 5.98.0(webpack-cli@5.1.4)
 
   htmlparser2@6.1.0:
@@ -7263,11 +7108,11 @@ snapshots:
       sass-embedded-win32-arm64: 1.100.0
       sass-embedded-win32-x64: 1.100.0
 
-  sass-loader@16.0.8(@rspack/core@2.1.1(@swc/helpers@0.5.23))(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.98.0):
+  sass-loader@16.0.8(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.98.0):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
-      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
+      '@rspack/core': '@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23)'
       sass: 1.100.0
       sass-embedded: 1.100.0
       webpack: 5.98.0(webpack-cli@5.1.4)
@@ -7304,10 +7149,10 @@ snapshots:
       ajv-formats: 2.1.1(ajv@8.17.1)
       ajv-keywords: 5.1.0(ajv@8.17.1)
 
-  script-ext-html-webpack-plugin@2.1.5(html-webpack-plugin@5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0))(webpack@5.98.0):
+  script-ext-html-webpack-plugin@2.1.5(html-webpack-plugin@5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0))(webpack@5.98.0):
     dependencies:
       debug: 4.4.3
-      html-webpack-plugin: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.98.0)
+      html-webpack-plugin: 5.6.7(@rspack-canary/core@2.1.4-canary-77f56582-20260708031112(@swc/helpers@0.5.23))(webpack@5.98.0)
       webpack: 5.98.0(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,27 @@ allowBuilds:
   core-js: false
   puppeteer: false
 
+minimumReleaseAgeExclude:
+  - '@rspack-canary/binding-darwin-arm64@2.1.4-canary-77f56582-20260708031112'
+  - '@rspack-canary/binding-darwin-x64@2.1.4-canary-77f56582-20260708031112'
+  - '@rspack-canary/binding-linux-arm64-gnu@2.1.4-canary-77f56582-20260708031112'
+  - '@rspack-canary/binding-linux-arm64-musl@2.1.4-canary-77f56582-20260708031112'
+  - '@rspack-canary/binding-linux-riscv64-gnu@2.1.4-canary-77f56582-20260708031112'
+  - '@rspack-canary/binding-linux-riscv64-musl@2.1.4-canary-77f56582-20260708031112'
+  - '@rspack-canary/binding-linux-x64-gnu@2.1.4-canary-77f56582-20260708031112'
+  - '@rspack-canary/binding-linux-x64-musl@2.1.4-canary-77f56582-20260708031112'
+  - '@rspack-canary/binding-wasm32-wasi@2.1.4-canary-77f56582-20260708031112'
+  - '@rspack-canary/binding-win32-arm64-msvc@2.1.4-canary-77f56582-20260708031112'
+  - '@rspack-canary/binding-win32-ia32-msvc@2.1.4-canary-77f56582-20260708031112'
+  - '@rspack-canary/binding-win32-x64-msvc@2.1.4-canary-77f56582-20260708031112'
+  - '@rspack-canary/binding@2.1.4-canary-77f56582-20260708031112'
+  - '@rspack-canary/cli@2.1.4-canary-77f56582-20260708031112'
+  - '@rspack-canary/core@2.1.4-canary-77f56582-20260708031112'
+
+overrides:
+  "@rspack/cli": "npm:@rspack-canary/cli@2.1.4-canary-77f56582-20260708031112"
+  "@rspack/core": "npm:@rspack-canary/core@2.1.4-canary-77f56582-20260708031112"
+
 peerDependencyRules:
   allowAny:
     - "@rspack/*"


### PR DESCRIPTION
## Summary

- Add pnpm overrides so `@rspack/core` and `@rspack/cli` resolve to the requested canary packages:
  - `@rspack-canary/core@2.1.4-canary-77f56582-20260708031112`
  - `@rspack-canary/cli@2.1.4-canary-77f56582-20260708031112`
- Refresh the generated `css-extract` prefetch/preload expected output for this canary runtime.
- Update the lockfile and pnpm release-age exclusions for the canary packages.

## Validation

- `pnpm testu` passed: 21 test files, 496 tests, 0 failures; snapshot added/updated/unmatched/removed all 0.
- `pnpm exec rspack --version` reports `rspack/2.1.4-canary-77f56582-20260708031112`.
- `require('@rspack/core/package.json')` resolves to `@rspack-canary/core@2.1.4-canary-77f56582-20260708031112`.

## Notes

- The local push reported that the repository moved from `rspack-contrib/rspack-plugin-ci` to `rstackjs/rspack-plugin-ci`, so this PR targets the new repository location.